### PR TITLE
Report missing credentials to the Rails application.

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -38,13 +38,13 @@ module OmniAuth
       def callback_phase
         @adaptor = OmniAuth::LDAP::Adaptor.new @options
 
-        # GITLAB security patch
-        # Dont allow blank password for ldap auth
-        if request['username'].nil? || request['username'].empty? || request['password'].nil? || request['password'].empty?
-          raise MissingCredentialsError.new("Missing login credentials") 
-        end
-
         begin
+          # GITLAB security patch
+          # Dont allow blank password for ldap auth
+          if request['username'].nil? || request['username'].empty? || request['password'].nil? || request['password'].empty?
+            raise MissingCredentialsError.new("Missing login credentials")
+          end
+
           @ldap_user_info = @adaptor.bind_as(:filter => Net::LDAP::Filter.eq(@adaptor.uid, @options[:name_proc].call(request['username'])),:size => 1, :password => request['password'])
           return fail!(:invalid_credentials) if !@ldap_user_info
 


### PR DESCRIPTION
If no username or password is provided a MissingCredentialsError is
raised which causes a Rack caught exception and a 500 Error in gitlab.
Omniauth provides a way to raise such errors to the application by
using the 'fail!' method to pass the exception to the registered
failure handler. For gitlab this is the omniauth_controller code.

This is required to resolve gitlab issue #1077.

Signed-off-by: Pat Thoyts patthoyts@users.sourceforge.net
