### PR TITLE
Fixes issues with LDAP search not passing bass correctly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 gemspec
-gem 'net-ldap', :git => "git://github.com/ruby-ldap/ruby-net-ldap.git"
 
 group :development, :test do
   gem 'guard'

--- a/omniauth-ldap.gemspec
+++ b/omniauth-ldap.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/intridea/omniauth-ldap"
 
   gem.add_runtime_dependency     'omniauth', '~> 1.0'
-  # gem.add_runtime_dependency     'net-ldap', '~> 0.2.2'
+  gem.add_runtime_dependency     'net-ldap', '~> 0.3.1'
   gem.add_runtime_dependency     'pyu-ruby-sasl', '~> 0.0.3.1'
   gem.add_runtime_dependency     'rubyntlm', '~> 0.1.1'  
   gem.add_development_dependency 'rspec', '~> 2.7'


### PR DESCRIPTION
This updates net-ldap library to 0.3.1 that addresses several issues with ldap search and how base is set. 

https://github.com/ruby-ldap/ruby-net-ldap/blob/master/History.rdoc
