### PR TITLE
Adding gid to LDAP Strategy

### DIFF
--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -18,7 +18,8 @@ module OmniAuth
         'uid' => 'dn',
         'url' => ['wwwhomepage'],
         'image' => 'jpegPhoto',
-        'description' => 'description'
+        'description' => 'description',
+        'gid' => 'gidNumber'
       }
       option :title, "LDAP Authentication" #default title for authentication form
       option :port, 389


### PR DESCRIPTION
LDAP now pulls gid number for user. This will be used in a pull request to gitlabhq to make certain users admins based on their LDAP gid number.
