### PR TITLE
Fix problem where the LDAP server returns alternate field

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gitlab_omniauth-ldap (1.0.2)
+    gitlab_omniauth-ldap (1.0.3)
       net-ldap (~> 0.3.1)
       omniauth (~> 1.0)
       pyu-ruby-sasl (~> 0.0.3.1)
@@ -12,11 +12,11 @@ GEM
   specs:
     coderay (1.0.8)
     diff-lcs (1.1.3)
-    hashie (1.2.0)
+    hashie (2.0.5)
     method_source (0.8.1)
     net-ldap (0.3.1)
-    omniauth (1.1.1)
-      hashie (~> 1.2)
+    omniauth (1.1.4)
+      hashie (>= 1.2, < 3)
       rack
     pry (0.9.10)
       coderay (~> 1.0.5)

--- a/lib/omniauth/strategies/ldap.rb
+++ b/lib/omniauth/strategies/ldap.rb
@@ -70,9 +70,11 @@ module OmniAuth
         mapper.each do |key, value|
           case value
           when String
-            user[key] = object[value.downcase.to_sym].first if object[value.downcase.to_sym]
+            user[key] = [object[value.downcase.to_sym]].flatten.first
           when Array
-            value.each {|v| (user[key] = object[v.downcase.to_sym].first; break;) if object[v.downcase.to_sym]}
+            user[key] = value.map { |v| 
+              [object[v.downcase.to_sym]].flatten.first 
+            }.compact.first
           when Hash
             value.map do |key1, value1|
               pattern = key1.dup


### PR DESCRIPTION
When connecting to an ActiveDirectory server, sometimes it returns the user e-mail in the "userPrincipalName" field, which causes the auth to fail. This pull requests slightly modify the object mapper to correctly fetch the values based on an array of field names.
